### PR TITLE
Update to a more recent version of the Freedesktop runtime

### DIFF
--- a/org.bzflag.BZFlag.json
+++ b/org.bzflag.BZFlag.json
@@ -1,7 +1,7 @@
 {
   "id": "org.bzflag.BZFlag",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "21.08",
+  "runtime-version": "23.08",
   "sdk": "org.freedesktop.Sdk",
   "command": "bzflag",
   "rename-icon": "bzflag",


### PR DESCRIPTION
Allows the BZFlag flatpak to be built with a newer version of the Freedesktop runtime